### PR TITLE
Unify navigation across pages

### DIFF
--- a/src/app/components/MainNav.js
+++ b/src/app/components/MainNav.js
@@ -1,0 +1,18 @@
+'use client'
+
+import Link from 'next/link'
+
+export default function MainNav() {
+  const linkClass = 'px-3 py-2 rounded-md text-gray-800 font-medium hover:bg-gray-100';
+  return (
+    <nav className="flex space-x-4">
+      <Link href="/" className={linkClass}>Home</Link>
+      <Link href="/scraped-contacts" className={linkClass}>Scraped Contacts</Link>
+      <Link href="/filtered-contacts" className={linkClass}>Filtered Contacts</Link>
+      <Link href="/email-campaign" className={linkClass}>Email Campaign</Link>
+      <Link href="/screenshot-review" className={linkClass}>Screenshot Review</Link>
+      <Link href="/crm" className={linkClass}>CRM</Link>
+      <Link href="/domain-export" className={linkClass}>Domain Export</Link>
+    </nav>
+  )
+}

--- a/src/app/crm/page.js
+++ b/src/app/crm/page.js
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
+import MainNav from '../components/MainNav';
 
 export default function CRMPage() {
   const [contacts, setContacts] = useState([]);
@@ -193,20 +194,7 @@ export default function CRMPage() {
             </div>
             <h1 className="text-2xl font-bold text-gray-800">Campaign CRM</h1>
           </div>
-          <nav className="flex space-x-4">
-            <Link href="/scraped-contacts" className="px-3 py-2 rounded-md text-gray-800 font-medium hover:bg-gray-100">
-              Scraped Contacts
-            </Link>
-            <Link href="/screenshot-review" className="px-3 py-2 rounded-md text-gray-800 font-medium hover:bg-gray-100">
-              Screenshot Review
-            </Link>
-            <Link href="/email-campaign" className="px-3 py-2 rounded-md text-gray-800 font-medium hover:bg-gray-100">
-              Email Campaign
-            </Link>
-            <Link href="/" className="px-3 py-2 rounded-md text-gray-800 font-medium hover:bg-gray-100">
-              Back to Search
-            </Link>
-          </nav>
+          <MainNav />
         </div>
       </header>
 

--- a/src/app/domain-export/page.js
+++ b/src/app/domain-export/page.js
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
+import MainNav from '../components/MainNav';
 
 export default function DomainExportPage() {
   const [websites, setWebsites] = useState('');
@@ -222,9 +223,7 @@ export default function DomainExportPage() {
       <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="mb-8 flex justify-between items-center">
           <h1 className="text-2xl font-bold text-gray-900">Domain Export Tool</h1>
-          <Link href="/email-campaign" className="text-indigo-600 hover:text-indigo-800">
-            Back to Email Campaign
-          </Link>
+          <MainNav />
         </div>
 
         <div className="bg-white shadow-lg rounded-xl overflow-hidden">

--- a/src/app/email-campaign/page.js
+++ b/src/app/email-campaign/page.js
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
+import MainNav from '../components/MainNav';
 
 // Hardcoded test websites as requested
 const TEST_WEBSITES = [
@@ -142,26 +143,8 @@ Make it sound natural and compelling.`
               </div>
               <h1 className="text-2xl font-bold text-gray-900">Email Campaign Generator</h1>
             </div>
-            <div className="flex space-x-4">
-              <Link href="/domain-export" className="text-indigo-600 hover:text-indigo-800">
-                Domain Export Tool
-              </Link>
-              <Link href="/screenshot-review" className="text-indigo-600 hover:text-indigo-800">
-                Screenshot Review
-              </Link>
-              <Link href="/" className="text-indigo-600 hover:text-indigo-800">
-                Back to Main
-              </Link>
-            </div>
+            <MainNav />
           </div>
-          <nav className="flex space-x-4">
-            <Link href="/scraped-contacts" className="px-3 py-2 rounded-md text-gray-800 font-medium hover:bg-gray-100">
-              Scraped Contacts
-            </Link>
-            <Link href="/" className="px-3 py-2 rounded-md text-gray-800 font-medium hover:bg-gray-100">
-              Back to Search
-            </Link>
-          </nav>
         </div>
       </header>
 

--- a/src/app/filtered-contacts/page.js
+++ b/src/app/filtered-contacts/page.js
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
+import MainNav from '../components/MainNav';
 
 const FilteredContactsPage = () => {
   const [contacts, setContacts] = useState([]);
@@ -43,17 +44,7 @@ const FilteredContactsPage = () => {
             </div>
             <h1 className="text-2xl font-bold text-gray-800">Filtered Contacts</h1>
           </div>
-          <nav className="flex space-x-4">
-            <Link href="/scraped-contacts" className="px-4 py-2 rounded-md bg-indigo-600 text-white hover:bg-indigo-700">
-              Scraped Contacts
-            </Link>
-            <Link href="/email-campaign" className="px-3 py-2 rounded-md text-gray-800 font-medium hover:bg-gray-100">
-              Email Campaign
-            </Link>
-            <Link href="/" className="px-3 py-2 rounded-md text-gray-800 font-medium hover:bg-gray-100">
-              Back to Search
-            </Link>
-          </nav>
+          <MainNav />
         </div>
       </header>
 

--- a/src/app/reviewed-contacts/page.js
+++ b/src/app/reviewed-contacts/page.js
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
+import MainNav from '../components/MainNav';
 
 export default function ReviewedContactsPage() {
   const [loading, setLoading] = useState(true);
@@ -183,17 +184,7 @@ export default function ReviewedContactsPage() {
             </div>
             <h1 className="text-2xl font-bold text-gray-800">Reviewed Contacts</h1>
           </div>
-          <nav className="flex space-x-4">
-            <Link href="/scraped-contacts" className="px-3 py-2 rounded-md text-gray-800 font-medium hover:bg-gray-100">
-              Scraped Contacts
-            </Link>
-            <Link href="/screenshot-review" className="px-3 py-2 rounded-md text-gray-800 font-medium hover:bg-gray-100">
-              Screenshot Review
-            </Link>
-            <Link href="/" className="px-3 py-2 rounded-md text-gray-800 font-medium hover:bg-gray-100">
-              Back to Search
-            </Link>
-          </nav>
+          <MainNav />
         </div>
       </header>
 

--- a/src/app/scraped-contacts/page.js
+++ b/src/app/scraped-contacts/page.js
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
+import MainNav from '../components/MainNav';
 
 const ScrapedContactsPage = () => {
   const [filteredContacts, setFilteredContacts] = useState([]);
@@ -213,17 +214,7 @@ const ScrapedContactsPage = () => {
             </div>
             <h1 className="text-2xl font-bold text-gray-800">Scraped Contacts</h1>
           </div>
-          <nav className="flex space-x-4">
-            <Link href="/filtered-contacts" className="px-3 py-2 rounded-md text-gray-800 font-medium hover:bg-gray-100">
-              Filtered Contacts
-            </Link>
-            <Link href="/email-campaign" className="px-3 py-2 rounded-md text-gray-800 font-medium hover:bg-gray-100">
-              Email Campaign
-            </Link>
-            <Link href="/" className="px-3 py-2 rounded-md text-gray-800 font-medium hover:bg-gray-100">
-              Back to Search
-            </Link>
-          </nav>
+          <MainNav />
         </div>
       </header>
 

--- a/src/app/screenshot-review/page.js
+++ b/src/app/screenshot-review/page.js
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
+import MainNav from '../components/MainNav';
 
 export default function ScreenshotReviewPage() {
   const [manifest, setManifest] = useState([]);
@@ -340,9 +341,7 @@ export default function ScreenshotReviewPage() {
                 {processingScreenshots ? 'Processing...' : 'Generate Screenshots'}
               </button>
               
-              <Link href="/" className="px-3 py-1 text-sm rounded border border-gray-300 hover:bg-gray-50 transition">
-                Home
-              </Link>
+              <MainNav />
               
               <button 
                 onClick={handleDownload}


### PR DESCRIPTION
## Summary
- add reusable `MainNav` component with links to all major pages
- insert `MainNav` into header of domain management pages

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68489c2818388330a532572f2ab9a48f