### PR TITLE
Improve mobile nav responsiveness

### DIFF
--- a/src/app/crm/page.js
+++ b/src/app/crm/page.js
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
+import Navbar from '@/components/Navbar';
 
 export default function CRMPage() {
   const [contacts, setContacts] = useState([]);
@@ -193,20 +194,14 @@ export default function CRMPage() {
             </div>
             <h1 className="text-2xl font-bold text-gray-800">Campaign CRM</h1>
           </div>
-          <nav className="flex space-x-4">
-            <Link href="/scraped-contacts" className="px-3 py-2 rounded-md text-gray-800 font-medium hover:bg-gray-100">
-              Scraped Contacts
-            </Link>
-            <Link href="/screenshot-review" className="px-3 py-2 rounded-md text-gray-800 font-medium hover:bg-gray-100">
-              Screenshot Review
-            </Link>
-            <Link href="/email-campaign" className="px-3 py-2 rounded-md text-gray-800 font-medium hover:bg-gray-100">
-              Email Campaign
-            </Link>
-            <Link href="/" className="px-3 py-2 rounded-md text-gray-800 font-medium hover:bg-gray-100">
-              Back to Search
-            </Link>
-          </nav>
+          <Navbar
+            links={[
+              { href: '/scraped-contacts', label: 'Scraped Contacts' },
+              { href: '/screenshot-review', label: 'Screenshot Review' },
+              { href: '/email-campaign', label: 'Email Campaign' },
+              { href: '/', label: 'Back to Search' },
+            ]}
+          />
         </div>
       </header>
 

--- a/src/app/email-campaign/page.js
+++ b/src/app/email-campaign/page.js
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
+import Navbar from '@/components/Navbar';
 
 // Hardcoded test websites as requested
 const TEST_WEBSITES = [
@@ -142,7 +143,7 @@ Make it sound natural and compelling.`
               </div>
               <h1 className="text-2xl font-bold text-gray-900">Email Campaign Generator</h1>
             </div>
-            <div className="flex space-x-4">
+            <div className="flex flex-wrap gap-2 sm:space-x-4 sm:gap-0">
               <Link href="/domain-export" className="text-indigo-600 hover:text-indigo-800">
                 Domain Export Tool
               </Link>
@@ -154,14 +155,12 @@ Make it sound natural and compelling.`
               </Link>
             </div>
           </div>
-          <nav className="flex space-x-4">
-            <Link href="/scraped-contacts" className="px-3 py-2 rounded-md text-gray-800 font-medium hover:bg-gray-100">
-              Scraped Contacts
-            </Link>
-            <Link href="/" className="px-3 py-2 rounded-md text-gray-800 font-medium hover:bg-gray-100">
-              Back to Search
-            </Link>
-          </nav>
+          <Navbar
+            links={[
+              { href: '/scraped-contacts', label: 'Scraped Contacts' },
+              { href: '/', label: 'Back to Search' },
+            ]}
+          />
         </div>
       </header>
 

--- a/src/app/filtered-contacts/page.js
+++ b/src/app/filtered-contacts/page.js
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
+import Navbar from '@/components/Navbar';
 
 const FilteredContactsPage = () => {
   const [contacts, setContacts] = useState([]);
@@ -43,17 +44,13 @@ const FilteredContactsPage = () => {
             </div>
             <h1 className="text-2xl font-bold text-gray-800">Filtered Contacts</h1>
           </div>
-          <nav className="flex space-x-4">
-            <Link href="/scraped-contacts" className="px-4 py-2 rounded-md bg-indigo-600 text-white hover:bg-indigo-700">
-              Scraped Contacts
-            </Link>
-            <Link href="/email-campaign" className="px-3 py-2 rounded-md text-gray-800 font-medium hover:bg-gray-100">
-              Email Campaign
-            </Link>
-            <Link href="/" className="px-3 py-2 rounded-md text-gray-800 font-medium hover:bg-gray-100">
-              Back to Search
-            </Link>
-          </nav>
+          <Navbar
+            links={[
+              { href: '/scraped-contacts', label: 'Scraped Contacts' },
+              { href: '/email-campaign', label: 'Email Campaign' },
+              { href: '/', label: 'Back to Search' },
+            ]}
+          />
         </div>
       </header>
 

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -535,7 +535,7 @@ export default function Home() {
             </div>
             <h1 className="text-2xl font-semibold text-white">Email Finder</h1>
           </div>
-          <nav className="flex items-center space-x-4 text-gray-200">
+          <nav className="flex flex-wrap items-center gap-2 sm:space-x-4 sm:gap-0 text-gray-200">
             <button
               onClick={() => setActiveTab('search')}
               className={`px-3 py-2 rounded-md text-sm ${activeTab === 'search' ? 'bg-white text-gray-900' : 'hover:bg-gray-700 hover:text-white'}`}

--- a/src/app/reviewed-contacts/page.js
+++ b/src/app/reviewed-contacts/page.js
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
+import Navbar from '@/components/Navbar';
 
 export default function ReviewedContactsPage() {
   const [loading, setLoading] = useState(true);
@@ -183,17 +184,13 @@ export default function ReviewedContactsPage() {
             </div>
             <h1 className="text-2xl font-bold text-gray-800">Reviewed Contacts</h1>
           </div>
-          <nav className="flex space-x-4">
-            <Link href="/scraped-contacts" className="px-3 py-2 rounded-md text-gray-800 font-medium hover:bg-gray-100">
-              Scraped Contacts
-            </Link>
-            <Link href="/screenshot-review" className="px-3 py-2 rounded-md text-gray-800 font-medium hover:bg-gray-100">
-              Screenshot Review
-            </Link>
-            <Link href="/" className="px-3 py-2 rounded-md text-gray-800 font-medium hover:bg-gray-100">
-              Back to Search
-            </Link>
-          </nav>
+          <Navbar
+            links={[
+              { href: '/scraped-contacts', label: 'Scraped Contacts' },
+              { href: '/screenshot-review', label: 'Screenshot Review' },
+              { href: '/', label: 'Back to Search' },
+            ]}
+          />
         </div>
       </header>
 
@@ -240,7 +237,7 @@ export default function ReviewedContactsPage() {
           
           {/* Tabs */}
           <div className="border-b border-gray-200">
-            <nav className="flex">
+            <nav className="flex flex-col sm:flex-row">
               <button
                 onClick={() => setActiveTab('approved')}
                 className={`px-4 py-3 text-sm font-medium ${

--- a/src/app/scraped-contacts/page.js
+++ b/src/app/scraped-contacts/page.js
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
+import Navbar from '@/components/Navbar';
 
 const ScrapedContactsPage = () => {
   const [filteredContacts, setFilteredContacts] = useState([]);
@@ -213,17 +214,13 @@ const ScrapedContactsPage = () => {
             </div>
             <h1 className="text-2xl font-bold text-gray-800">Scraped Contacts</h1>
           </div>
-          <nav className="flex space-x-4">
-            <Link href="/filtered-contacts" className="px-3 py-2 rounded-md text-gray-800 font-medium hover:bg-gray-100">
-              Filtered Contacts
-            </Link>
-            <Link href="/email-campaign" className="px-3 py-2 rounded-md text-gray-800 font-medium hover:bg-gray-100">
-              Email Campaign
-            </Link>
-            <Link href="/" className="px-3 py-2 rounded-md text-gray-800 font-medium hover:bg-gray-100">
-              Back to Search
-            </Link>
-          </nav>
+          <Navbar
+            links={[
+              { href: '/filtered-contacts', label: 'Filtered Contacts' },
+              { href: '/email-campaign', label: 'Email Campaign' },
+              { href: '/', label: 'Back to Search' },
+            ]}
+          />
         </div>
       </header>
 

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -1,0 +1,49 @@
+'use client';
+import { useState } from 'react';
+import Link from 'next/link';
+
+export default function Navbar({ links = [] }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      {/* Toggle button */}
+      <button
+        className="sm:hidden p-2 rounded-md text-gray-600 hover:bg-gray-100 focus:outline-none"
+        onClick={() => setOpen(!open)}
+        aria-label="Toggle navigation"
+      >
+        {open ? (
+          <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        ) : (
+          <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        )}
+      </button>
+
+      {/* Overlay */}
+      {open && <div className="fixed inset-0 z-30 bg-black/50 sm:hidden" onClick={() => setOpen(false)} />}
+
+      {/* Sidebar / nav container */}
+      <div
+        className={`fixed inset-y-0 left-0 z-40 w-64 bg-white shadow-lg transform transition-transform sm:static sm:shadow-none sm:translate-x-0 ${open ? 'translate-x-0' : '-translate-x-full sm:translate-x-0'}`}
+      >
+        <nav className="flex flex-col p-4 space-y-2 sm:flex-row sm:space-y-0 sm:space-x-4">
+          {links.map(link => (
+            <Link
+              key={link.href}
+              href={link.href}
+              className="text-gray-800 font-medium hover:text-indigo-600"
+              onClick={() => setOpen(false)}
+            >
+              {link.label}
+            </Link>
+          ))}
+        </nav>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- create a reusable `Navbar` component with mobile toggle
- use `Navbar` across pages
- tweak existing nav layouts for small screens
- update mobile menu to slide in from the side with overlay

## Testing
- `PUPPETEER_SKIP_DOWNLOAD=1 npm install`
- `npm run lint` *(prompts to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_6848a7a6cb688330ac8da535b5bd7e1c