### PR TITLE
Add animated mobile sidebar menu

### DIFF
--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -8,20 +8,32 @@ export default function Navbar({ links = [] }) {
   return (
     <div className="relative">
       <button
-        className="sm:hidden p-2 rounded-md text-gray-600 hover:bg-gray-100 focus:outline-none"
+        className="sm:hidden relative w-8 h-8 focus:outline-none"
         onClick={() => setOpen(!open)}
         aria-label="Toggle navigation"
       >
-        <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
+        <span
+          className={`absolute block h-0.5 w-8 bg-gray-600 transform transition duration-300 ease-in-out ${
+            open ? 'rotate-45 top-3.5' : 'top-2'
+          }`}
+        ></span>
+        <span
+          className={`absolute block h-0.5 w-8 bg-gray-600 transition duration-300 ease-in-out ${
+            open ? 'opacity-0' : 'top-4'
+          }`}
+        ></span>
+        <span
+          className={`absolute block h-0.5 w-8 bg-gray-600 transform transition duration-300 ease-in-out ${
+            open ? '-rotate-45 top-3.5' : 'top-6'
+          }`}
+        ></span>
       </button>
       <nav
         className={`${
-          open ? 'block' : 'hidden'
-        } absolute right-0 mt-2 w-48 bg-white shadow-md rounded-md sm:static sm:mt-0 sm:block sm:w-auto sm:bg-transparent sm:shadow-none`}
+          open ? 'translate-x-0' : '-translate-x-full'
+        } fixed top-0 left-0 h-full w-64 bg-white shadow-lg transform transition-transform duration-300 sm:static sm:h-auto sm:w-auto sm:bg-transparent sm:shadow-none sm:translate-x-0`}
       >
-        <div className="flex flex-col sm:flex-row sm:items-center">
+        <div className="mt-16 sm:mt-0 flex flex-col sm:flex-row sm:items-center">
           {links.map(link => (
             <Link
               key={link.href}


### PR DESCRIPTION
## Summary
- animate navbar hamburger icon
- open sidebar on small screens

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848aecb008c83309ff4f6b58c7b46a1